### PR TITLE
Better birth date handling

### DIFF
--- a/src/test/scala/ChatterBotSpec.scala
+++ b/src/test/scala/ChatterBotSpec.scala
@@ -144,4 +144,55 @@ class ChatterBotSpec extends Specification {
     }
   }
 
+  "parseBirthDate" should {
+    "accept complete dates regardless of the year" in {
+      ChatterBot.parseBirthDate("17/4/1870") must be equalTo (LocalDate.of(
+        1870,
+        4,
+        17
+      ))
+      ChatterBot.parseBirthDate("17/4/2030") must be equalTo (LocalDate.of(
+        2030,
+        4,
+        17
+      ))
+    }
+
+    "complete two-digits years" in {
+      ChatterBot.parseBirthDate("1/2/3") must be equalTo (LocalDate
+        .of(2003, 2, 1))
+      ChatterBot.parseBirthDate("17/1/78") must be equalTo (LocalDate
+        .of(1978, 1, 17))
+    }
+
+    "fail on invalid dates" in {
+      ChatterBot.parseBirthDate("1/17/78") must throwA[RuntimeException]
+      ChatterBot.parseBirthDate("29/2/1900") must throwA[RuntimeException]
+    }
+  }
+
+  "checkBirthDate" should {
+    "reject invalid dates" in {
+      ChatterBot.checkBirthDate("9/13/1990") must beSome
+      ChatterBot.checkBirthDate("29/2/1900") must beSome
+    }
+
+    "accept plausible dates" in {
+      ChatterBot.checkBirthDate("29/2/2000") must beNone
+      ChatterBot.checkBirthDate("13/9/1922") must beNone
+      ChatterBot.checkBirthDate("13/9/1967") must beNone
+      ChatterBot.checkBirthDate("13/9/67") must beNone
+      ChatterBot.checkBirthDate("22/3/2008") must beNone
+      ChatterBot.checkBirthDate("22/3/8") must beNone
+    }
+
+    "reject dates in the future" in {
+      ChatterBot.checkBirthDate("13/9/2030") must beSome
+    }
+
+    "reject dates too far in the past" in {
+      ChatterBot.checkBirthDate("13/9/1890") must beSome
+    }
+  }
+
 }


### PR DESCRIPTION
The birth date handling has been modified such that:

  - A year in [0, 20] is moved into the 2000-2020 range.
  - A year in [21, 99] is moved into the 1921-1999 range.
  - Dates in the future or more than 110 years in the past
    are reported as erroneous.
  - Bug fix: invalid non-leap-year Feb 29 are not silently
    moved one day earlier, they are signalled as an error.