### PR TITLE
Increase stash capacity

### DIFF
--- a/src/main/scala/ChatterBot.scala
+++ b/src/main/scala/ChatterBot.scala
@@ -128,7 +128,7 @@ private class ChatterBot(
     * `/start` to start data collection in which case we branch to `requestData`.
     */
   val startingPoint: Behavior[ChatterBotControl] = {
-    Behaviors.withStash[ChatterBotControl](5) { buffer =>
+    Behaviors.withStash[ChatterBotControl](10) { buffer =>
       Behaviors.receiveMessage {
         case CachedData(data) =>
           buffer.unstashAll(handleCommands(data))


### PR DESCRIPTION
This might be useful in case of Telegram servers hiccups, but it is
mainly there to allow testing to send all the needed information
at once while the actor is starting. It is kept low enough not to
accumulate too many requests.