### PR TITLE
User can input document time as an hour only

### DIFF
--- a/src/main/scala/ChatterBot.scala
+++ b/src/main/scala/ChatterBot.scala
@@ -617,7 +617,7 @@ object ChatterBot {
           val time =
             LocalTime.parse(
               spec.replace(':', 'h'),
-              DateTimeFormatter.ofPattern("H'h'mm")
+              DateTimeFormatter.ofPattern("H'h'[mm]")
             )
           addCredibleDate(time, now)
             .map(dt => Right(dt))


### PR DESCRIPTION
When specifying a user-set start time for a document, for instance 12h00, the user has to type "12h00", whereas the handy and usual way of typing this is "12h".
This PR supports both typing styles.

The only concern I have is that we'd therefore support inputs like "12:" whereas it's clearly an unusual way of typing.
This may be solved by using a regex instead of the current literal replacement (`spec.replace(':', 'h')`)-if deemed useful/not overkill.