### PR TITLE
Rename interrquest-delay to inter-request-delay

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,7 +8,7 @@ ausweis {
   disabled = false
 
   // Rate limiting of incoming requests per user
-  interrequest-delay = 1 second
+  inter-request-delay = 1 second
   max-queued-requests = 5
 
   // Fill this to get debugging traces on Telegram


### PR DESCRIPTION
This is a non-backward compatible change; configuration which
have overriden the default value of this parameter must be
updated.
