### PR TITLE
When /start-ing, start with new and clear initial data

### DIFF
--- a/src/main/scala/ChatterBot.scala
+++ b/src/main/scala/ChatterBot.scala
@@ -76,7 +76,7 @@ private class ChatterBot(
     )
   }
 
-  private[this] val initialData =
+  private[this] def initialData =
     new IncompletePersonalData(Some(user.firstName), user.lastName)
 
   // Start by requesting stored data about the user. We treat an error
@@ -296,7 +296,10 @@ private class ChatterBot(
         Behaviors.same
       case FromMainBot(PrivateCommand("i", Seq())) =>
         db ! DBProtocol.Delete(user.id)
-        requestData(IncompletePersonalData.forgetIdentity(data, user.firstName, user.lastName))
+        requestData(
+          IncompletePersonalData
+            .forgetIdentity(data, user.firstName, user.lastName)
+        )
       case FromMainBot(PrivateCommand("l", Seq())) =>
         db ! DBProtocol.Delete(user.id)
         requestData(IncompletePersonalData.forgetAddress(data))


### PR DESCRIPTION
Using a val would have reused the same value over time.

Fix #52
