### PR TITLE
Enhance documentation

### DIFF
--- a/src/main/resources/help.md
+++ b/src/main/resources/help.md
@@ -1,13 +1,20 @@
 La finalité de ce bot (dont le [code source est librement disponible](https://github.com/samueltardieu/AusweisBot)) est la génération d'auto-attestations dérogatoires de sortie respectant les prescriptions réglementaires sous la seule responsabilité de l'utilisateur de ce service. Ces attestations incluent un QR-code permettant aux forces de l'ordre d'en vérifier le contenu tout en respectant les distances de sécurité.
 
+Pour interagir avec le bot, il faut lui envoyer un message contenant une commande. Une commande commence toujours par le symbole `/` suivi du nom de la commande.
+
 Les commandes suivantes sont disponibles à tout moment :
 
-- `/help` : Cette aide
-- `/start` : Efface toutes les données personnelles et recommence la saisie
-- `/privacy` : Indique la politique de traitement des données personnelles
-- `/data` : Liste les données personnelles
+- /help : Cette aide
+- /start : Efface toutes les données personnelles et recommence la saisie
+- /privacy : Indique la politique de traitement des données personnelles
+- /data : Liste les données personnelles
 
-Les commandes suivantes sont disponibles une fois que les données personnelles nécessaires à la génération des attestations ont été fournies :
+Les commandes suivantes génèrent une attestation pour un motif donné.
+Elles sont disponibles une fois que les données personnelles nécessaires à la génération des attestations ont été fournies :
+
+REASONS
+
+*Utilisation avancée*
 
 - `/sport` : Génère une attestation pour la pratique sportive, la promenade ou la sortie des animaux.
 - `/sport oubli` : Idem daté d'il y a une vingtaine de minutes en cas d'oubli de sauvegarde de l'attestation avant de sortir.
@@ -15,14 +22,10 @@ Les commandes suivantes sont disponibles une fois que les données personnelles 
 - `/autre motifs`, `/autre motifs oubli` ou `/autre motifs 11h30` : Attestation pour un ou plusieurs motifs séparés par `+` (par exemple `/autre courses+sport 10h30`).
 - `/vierge` : Fournit un formulaire pré-rempli à imprimer, compléter et signer.
 
-La liste des motifs utilisables est :
-
-REASONS
-
 Les commandes suivantes permettent de changer certains détails stockés en base de données :
 
-- `/a` : Permet de changer l'adresse en conservant l'identité actuelle
-- `/i` : Permet de changer l'identité en conservant l'adresse actuelle
+- /a : Permet de changer l'adresse en conservant l'identité actuelle
+- /i : Permet de changer l'identité en conservant l'adresse actuelle
 
 Telegram ne transmettant pas le fuseau horaire dans lequel se trouve l'utilisateur, la génération des attestations sans heure explicite ne fonctionne que pour la France métropolitaine.
 

--- a/src/main/scala/Ausweis.scala
+++ b/src/main/scala/Ausweis.scala
@@ -17,6 +17,7 @@ import com.bot4s.telegram.models.{ChatId, User}
 import com.typesafe.config.ConfigFactory
 import models.Authorization
 import org.apache.commons.io.IOUtils
+import org.apache.commons.lang3.StringUtils
 import slogging.{LogLevel, LoggerConfig, PrintLoggerFactory}
 import sun.misc.{Signal, SignalHandler}
 
@@ -57,7 +58,7 @@ object Ausweis extends App {
     val reasons: String = Authorization.reasonsAndAliases.zipWithIndex
       .map {
         case ((reason, aliases, help), i) =>
-          s"- Case ${i + 1} : `/$reason`${if (aliases.nonEmpty)
+          s"- Case ${i + 1} : /${StringUtils.stripAccents(reason)}${if (aliases.nonEmpty)
             s" (ou ${aliases.map(a => s"`/$a`").mkString(", ")})"
           else ""} - $help"
       }


### PR DESCRIPTION
Allow clicking on without-parameter-commands within the help message.
Reword help message to prioritize valid reasons over command formatting.